### PR TITLE
Flat map for prettier Slack output when pages conflicted

### DIFF
--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -495,16 +495,18 @@ export class Rerouter {
         return matches[0];
       default:
         if (this.rerouterConfig.strictMode) {
+          let matchNames = matches.flatMap(item => item.matchedPages.map(page => page.name));
+
           Utils.saveImageToDisk(DefaultRerouterConfig.deviceId, 'conflictedRoutes');
           if (this.rerouterConfig.debugSlackUrl !== '') {
             Utils.sendSlackMessage(
               this.rerouterConfig.debugSlackUrl,
               'Conflict Routes Report',
-              `${DefaultRerouterConfig.deviceId} just logged a conflict route image`
+              `${DefaultRerouterConfig.deviceId} just logged a conflict route image: ${JSON.stringify(matchNames)}`
             );
           }
 
-          throw new Error(`Intentional crash due to multiple route applied to current screen: ${JSON.stringify(matches)}`);
+          throw new Error(`Intentional crash due to multiple route applied to current screen: ${JSON.stringify(matchNames)}`);
         } else {
           keycode('KEYCODE_BACK', 100);
           return { matchedRoute: null, matchedPages: [] };

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -495,7 +495,6 @@ export class Rerouter {
         return matches[0];
       default:
         if (this.rerouterConfig.strictMode) {
-          // let matchNames = matches.flatMap(item => item.matchedPages.map(page => page.name));
           let matchNames = matches.reduce(function (acc: string[], item) {
             return acc.concat(
               item.matchedPages.map(function (page) {

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -495,7 +495,14 @@ export class Rerouter {
         return matches[0];
       default:
         if (this.rerouterConfig.strictMode) {
-          let matchNames = matches.flatMap(item => item.matchedPages.map(page => page.name));
+          // let matchNames = matches.flatMap(item => item.matchedPages.map(page => page.name));
+          let matchNames = matches.reduce(function (acc: string[], item) {
+            return acc.concat(
+              item.matchedPages.map(function (page) {
+                return page.name;
+              })
+            );
+          }, []);
 
           Utils.saveImageToDisk(DefaultRerouterConfig.deviceId, 'conflictedRoutes');
           if (this.rerouterConfig.debugSlackUrl !== '') {


### PR DESCRIPTION
before: 
Conflict Routes Report
testing just logged a conflict route image

after: 
Conflict Routes Report
testing just logged a conflict route image: ["rfpageBattleVictoryButNeedTap","rfpageBattleFinishedWithMVPCookie"]
