### PR TITLE
fea: `findMatchedRouteImpl` always dup routes warning

### DIFF
--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -529,22 +529,20 @@ export class Rerouter {
       case 1:
         return matches[0];
       default:
-        if (this.rerouterConfig.strictMode) {
-          let matchNames = matches.reduce(function (acc: string[], item) {
-            return acc.concat(
-              item.matchedPages.map(function (page) {
-                return page.name;
-              })
-            );
-          }, []);
+        const matchNames = matches.reduce(function (acc: string[], item) {
+          return acc.concat(
+            item.matchedPages.map(function (page) {
+              return page.name;
+            })
+          );
+        }, []);
+        const warningMsg = `a route conflict when in Task: "${taskName}", names: ${JSON.stringify(matchNames)}`;
+        this.warning(warningMsg);
 
+        if (this.rerouterConfig.strictMode) {
           Utils.saveScreenshotToDisk(this.rerouterConfig.saveImageRoot, `${DefaultRerouterConfig.deviceId}_conflictedRoutes`);
           if (this.rerouterConfig.debugSlackUrl !== '') {
-            Utils.sendSlackMessage(
-              this.rerouterConfig.debugSlackUrl,
-              'Conflict Routes Report',
-              `${DefaultRerouterConfig.deviceId} just logged a route conflict when in Task: "${taskName}", names: ${JSON.stringify(matchNames)}`
-            );
+            Utils.sendSlackMessage(this.rerouterConfig.debugSlackUrl, 'Conflict Routes Report', `${DefaultRerouterConfig.deviceId} just logged ${warningMsg}`);
           }
 
           throw new Error(`Intentional crash due to multiple route applied to current screen: ${JSON.stringify(matchNames)}`);


### PR DESCRIPTION
reason:
current is difficult to tell if it's no match or has dup routes if not turn on strict mode
especially for non-cloud user who cannot send slack msg