### PR TITLE
Respect XYRGB threshold and allow inverted threshold matching

### DIFF
--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -641,12 +641,13 @@ export class Rerouter {
   }
 
   private isMatchPageImpl(image: Image, page: Page, parentThres: number, debug: boolean): boolean {
-    const thres = page.thres ?? parentThres;
+    const pageThres = page.thres;
     let isSame = true;
     this.logImpl(debug, `checkMatchPage[${page.name}]`);
 
-    for (let i = 0; i < page.points.length; i++) {
+    for (let i = 0; isSame && i < page.points.length; i++) {
       const point = page.points[i];
+      const thres = point.thres ?? pageThres ?? parentThres;
       const color = getImageColor(image, point.x, point.y);
       const score = Utils.identityColor(point, color);
       const isPointColorMatch = score >= thres;
@@ -658,7 +659,6 @@ export class Rerouter {
           `expect: ${Utils.formatXYRGB(point)}\n`,
           `   get: ${Utils.formatXYRGB({ ...color, x: point.x, y: point.y })}`
         );
-        break;
       }
     }
 

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -648,9 +648,10 @@ export class Rerouter {
     for (let i = 0; isSame && i < page.points.length; i++) {
       const point = page.points[i];
       const thres = point.thres ?? pageThres ?? parentThres;
+      const shouldMatch = point.match ?? true;
       const color = getImageColor(image, point.x, point.y);
       const score = Utils.identityColor(point, color);
-      const isPointColorMatch = score >= thres;
+      const isPointColorMatch = (score >= thres) === shouldMatch;
       if (!isPointColorMatch) {
         isSame = false;
         this.logImpl(

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -18,6 +18,8 @@ export interface XYRGB {
   g: number;
   b: number;
   thres?: number;
+  /** Set to false when the defined RGB should **not** match the actual point. If no value is set, `true` is assumed. */
+  match?: boolean;
 }
 
 export class Page {


### PR DESCRIPTION
⚠️ **This might break existing page matching** ⚠️ 

Sadly, there is a property `thres` within the `XYRGB` struct which isn't interpreted until 937b71b0. But I think this PR will correct the intended behavior, especially as there are areas within one page where one can define quite low thresholds for some uni-color areas and some more tolerant thresholds where multiple colors exist on small areas but where a color check is necessary.

The second commit's idea is copied from TsumBeta and at least for me relevant because I already use it there. 