### PR TITLE
feat: make beforeTask/afterTask the primary names for task hooks

### DIFF
--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -367,6 +367,8 @@ export class Rerouter {
   }
 
   private wrapTaskConfigWithDefault(config: TaskConfig): Required<TaskConfig> {
+    const beforeTask = config.beforeTask ?? config.beforeRoute ?? null;
+    const afterTask = config.afterTask ?? config.afterRoute ?? null;
     return {
       name: config.name,
       maxTaskRunTimes: config.maxTaskRunTimes ?? this.defaultConfig.TaskConfigMaxTaskRunTimes,
@@ -374,8 +376,10 @@ export class Rerouter {
       minRoundInterval: config.minRoundInterval ?? this.defaultConfig.TaskConfigMinRoundInterval,
       forceStop: config.forceStop ?? this.defaultConfig.TaskConfigAutoStop,
       findRouteDelay: config.findRouteDelay ?? this.defaultConfig.TaskConfigFindRouteDelay,
-      beforeRoute: config.beforeRoute ?? null,
-      afterRoute: config.afterRoute ?? null,
+      beforeTask,
+      afterTask,
+      beforeRoute: beforeTask,
+      afterRoute: afterTask,
     };
   }
 

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -146,7 +146,15 @@ export interface TaskConfig {
   /**
    * Do something before go into matching route loop, if return 'skipRouteLoop', it will not go into matching route loop
    */
+  beforeTask?: null | ((task: Task) => void | 'skipRouteLoop');
+  afterTask?: null | ((task: Task) => void);
+  /**
+   * Alias for beforeTask (for backward compatibility)
+   */
   beforeRoute?: null | ((task: Task) => void | 'skipRouteLoop');
+  /**
+   * Alias for afterTask (for backward compatibility)
+   */
   afterRoute?: null | ((task: Task) => void);
 }
 


### PR DESCRIPTION
## Changes\n- Made / the primary names for task hooks in  interface\n- Kept / as backward-compatible aliases\n- Updated documentation to reflect this change\n- Modified  to prioritize / values\n\n## Why\nThis change better reflects the actual purpose of these hooks - they are task-level operations rather than route-level operations. The / names are kept for backward compatibility with existing code.\n\n## Testing\n- [ ] Verify that both / and / work as expected\n- [ ] Confirm that existing code using / continues to work\n- [ ] Test that the priority order (beforeTask > beforeRoute) works correctly