### PR TITLE
feat: add allowedPackages to RerouterConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robotmon-rerouter",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "robotmon rerouter framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,7 +6,7 @@ export const DEFAULT_REROUTER_CONFIG: RerouterConfig = {
   taskDelay: 2000,
   startAppDelay: 6000,
   autoLaunchApp: true,
-  inAppPackageNames: [],
+  inAppExtraPackageNames: [],
   testingScreenshotPath: './screenshot',
   instanceId: '',
   deviceId: '',

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,7 +6,7 @@ export const DEFAULT_REROUTER_CONFIG: RerouterConfig = {
   taskDelay: 2000,
   startAppDelay: 6000,
   autoLaunchApp: true,
-  allowedPackages: [],
+  inAppPackageNames: [],
   testingScreenshotPath: './screenshot',
   instanceId: '',
   deviceId: '',

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,6 +6,7 @@ export const DEFAULT_REROUTER_CONFIG: RerouterConfig = {
   taskDelay: 2000,
   startAppDelay: 6000,
   autoLaunchApp: true,
+  allowedPackages: [],
   testingScreenshotPath: './screenshot',
   instanceId: '',
   deviceId: '',

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -227,6 +227,9 @@ export class Rerouter {
     if (packageName === this.rerouterConfig.packageName) {
       return true;
     }
+    if (this.rerouterConfig.allowedPackages.includes(packageName)) {
+      return true;
+    }
     return Utils.isAppOnTop(this.rerouterConfig.packageName);
   }
 

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -230,7 +230,7 @@ export class Rerouter {
     if (this.rerouterConfig.inAppPackageNames.includes(packageName)) {
       return true;
     }
-    return Utils.isAppOnTop(this.rerouterConfig.packageName);
+    return Utils.isAppOnTop([this.rerouterConfig.packageName, ...this.rerouterConfig.inAppPackageNames]);
   }
 
   public startApp(maxRetries: number = 3, retryDelay: number = 3000): void {

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -227,7 +227,7 @@ export class Rerouter {
     if (packageName === this.rerouterConfig.packageName) {
       return true;
     }
-    if (this.rerouterConfig.allowedPackages.includes(packageName)) {
+    if (this.rerouterConfig.inAppPackageNames.includes(packageName)) {
       return true;
     }
     return Utils.isAppOnTop(this.rerouterConfig.packageName);

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -223,14 +223,12 @@ export class Rerouter {
   }
 
   public checkInApp(): boolean {
+    const allPackageNames = [this.rerouterConfig.packageName, ...this.rerouterConfig.inAppPackageNames];
     const [packageName] = Utils.getCurrentApp();
-    if (packageName === this.rerouterConfig.packageName) {
+    if (allPackageNames.includes(packageName)) {
       return true;
     }
-    if (this.rerouterConfig.inAppPackageNames.includes(packageName)) {
-      return true;
-    }
-    return Utils.isAppOnTop([this.rerouterConfig.packageName, ...this.rerouterConfig.inAppPackageNames]);
+    return Utils.isAppOnTop(allPackageNames);
   }
 
   public startApp(maxRetries: number = 3, retryDelay: number = 3000): void {

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -223,7 +223,7 @@ export class Rerouter {
   }
 
   public checkInApp(): boolean {
-    const allPackageNames = [this.rerouterConfig.packageName, ...this.rerouterConfig.inAppPackageNames];
+    const allPackageNames = [this.rerouterConfig.packageName, ...this.rerouterConfig.inAppExtraPackageNames];
     const [packageName] = Utils.getCurrentApp();
     if (allPackageNames.includes(packageName)) {
       return true;

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -198,7 +198,7 @@ export interface RerouterConfig {
   startAppDelay: number;
   autoLaunchApp: boolean;
   /** Additional package names considered as "in app" (e.g. browser/WebView during OAuth login flow) */
-  inAppPackageNames: string[];
+  inAppExtraPackageNames: string[];
   testingScreenshotPath: string;
   instanceId: string; // the ID of the framework instance
   deviceId: string; // the ID of the device the framework runs on

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -197,6 +197,8 @@ export interface RerouterConfig {
   taskDelay: number;
   startAppDelay: number;
   autoLaunchApp: boolean;
+  /** Additional package names considered as "in app" (e.g. browser/WebView during OAuth login flow) */
+  allowedPackages: string[];
   testingScreenshotPath: string;
   instanceId: string; // the ID of the framework instance
   deviceId: string; // the ID of the device the framework runs on

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -198,7 +198,7 @@ export interface RerouterConfig {
   startAppDelay: number;
   autoLaunchApp: boolean;
   /** Additional package names considered as "in app" (e.g. browser/WebView during OAuth login flow) */
-  allowedPackages: string[];
+  inAppPackageNames: string[];
   testingScreenshotPath: string;
   instanceId: string; // the ID of the framework instance
   deviceId: string; // the ID of the device the framework runs on

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,7 +154,7 @@ export class Utils {
     return gameBoosterInfo.indexOf('GameBooster Lock Screen') !== -1 || gameBoosterInfo.toLowerCase().indexOf('gamebooster') !== -1;
   }
 
-  public static isAppOnTop(packageName: string): boolean {
+  public static isAppOnTop(packageName: string | string[]): boolean {
     // Check if screen is asleep first
     if (Utils.isScreenAsleep()) {
       // Press wakeup to wake up the screen
@@ -172,7 +172,8 @@ export class Utils {
 
     const topInfo = execute('dumpsys activity activities | grep mResumedActivity');
     // mResumedActivity: ActivityRecord{29199c5 u0 com.linecorp.LGTMTMG/com.linecorp.LGTMTM.TsumTsum t1872}
-    return topInfo.indexOf(`${packageName}/`) !== -1;
+    const packageNames = Array.isArray(packageName) ? packageName : [packageName];
+    return packageNames.some(pkg => topInfo.indexOf(`${pkg}/`) !== -1);
   }
 
   public static sendSlackMessage(url: string, title: string, message: string) {


### PR DESCRIPTION
## Summary
- `RerouterConfig` 新增 `allowedPackages: string[]`
- `checkInApp()` 現在同時檢查 `packageName` 和 `allowedPackages` 中的所有 package
- Bump version to 1.5.0

## Motivation
部分腳本（如 tsum-v2）在 LINE OAuth 登入流程中需要跳到瀏覽器/WebView，這段期間 foreground app 不是遊戲本身，導致 `checkInApp()` 回傳 `false`，framework 會嘗試重啟 app。

舊作法是在跳瀏覽器前把 `autoLaunchApp` 設成 `false`，登入完再設回 `true`，容易出現 app crash 時永遠卡住的 corner case。

`allowedPackages` 讓腳本直接宣告哪些 package 在前景時視為合法狀態，不再需要 toggle `autoLaunchApp`。