### PR TITLE
fix: replace includes/some with indexOf for JS runtime compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robotmon-rerouter",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "robotmon rerouter framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -225,7 +225,7 @@ export class Rerouter {
   public checkInApp(): boolean {
     const allPackageNames = [this.rerouterConfig.packageName, ...this.rerouterConfig.inAppExtraPackageNames];
     const [packageName] = Utils.getCurrentApp();
-    if (allPackageNames.includes(packageName)) {
+    if (allPackageNames.indexOf(packageName) !== -1) {
       return true;
     }
     return Utils.isAppOnTop(allPackageNames);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,7 +173,12 @@ export class Utils {
     const topInfo = execute('dumpsys activity activities | grep mResumedActivity');
     // mResumedActivity: ActivityRecord{29199c5 u0 com.linecorp.LGTMTMG/com.linecorp.LGTMTM.TsumTsum t1872}
     const packageNames = Array.isArray(packageName) ? packageName : [packageName];
-    return packageNames.some(pkg => topInfo.indexOf(`${pkg}/`) !== -1);
+    for (var i = 0; i < packageNames.length; i++) {
+      if (topInfo.indexOf(`${packageNames[i]}/`) !== -1) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static sendSlackMessage(url: string, title: string, message: string) {


### PR DESCRIPTION
## Summary
- `Array.prototype.includes` and `Array.prototype.some` are not available in the Robotmon JS runtime, causing a runtime error:
  ```
  TypeError: 'includes' is not a function
  ```
- Replace `includes` → `indexOf !== -1`
- Replace `some` → `for` loop with `indexOf`
- Bump version to 1.5.1