### PR TITLE
refactor: remove savePageReference debug feature

### DIFF
--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -75,11 +75,6 @@ export class Rerouter {
     this.screenConfig.screenHeight = this.screenConfig.screenHeight || dHeight;
     this.log(`screenWidth: ${this.screenConfig.screenWidth}, screenHeight: ${this.screenConfig.screenHeight}`);
     (this.screenConfig as any).logScreenshotFolder = this.rerouterConfig.deviceId; // Type assertion to bypass readonly restriction
-    if (this.rerouterConfig.savePageReference?.enable) {
-      const folderPath = this.rerouterConfig.savePageReference.folderPath || Utils.joinPaths(this.rerouterConfig.saveImageRoot, 'pageReference');
-      this.rerouterConfig.savePageReference.folderPath = folderPath;
-      execute(`mkdir -p ${folderPath}`);
-    }
 
     overrideConsole.setLogLevel(this.rerouterConfig.logger.logLevel);
     overrideConsole.setTimezoneOffsetHour(this.rerouterConfig.logger.timezoneOffsetHour);
@@ -696,7 +691,6 @@ export class Rerouter {
       this.warning(`Route: ${route.path} action execution error:`, error);
     }
 
-    this.savePageReferenceImage(image, matchedPages);
     Utils.sleep(route.afterActionDelay);
 
     // Execute afterRoute callback if defined
@@ -909,22 +903,6 @@ export class Rerouter {
     }
 
     return matchedPages;
-  }
-
-  private savePageReferenceImage(image: Image, matchedPages: Page[]): void {
-    const { enable, folderPath, rgba } = this.rerouterConfig.savePageReference || {};
-    if (!enable || !folderPath || matchedPages.length === 0) {
-      return;
-    }
-    matchedPages.forEach(page => {
-      Utils.savePointsMarkedImage({
-        image,
-        name: page.name,
-        points: page.points,
-        folderPath,
-        rgba,
-      });
-    });
   }
 
   private log(...args: any[]): void {

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -204,11 +204,6 @@ export interface RerouterConfig {
   deviceId: string; // the ID of the device the framework runs on
   strictMode: boolean;
   checkFrozenScreen: boolean; // enable/disable screen frozen detection
-  savePageReference?: {
-    enable: boolean;
-    folderPath: string;
-    rgba?: { r: number; g: number; b: number; a: number };
-  };
   debugSlackUrl: string;
   logger: {
     overrideGlobalConsole: boolean; // if true, this will override global console among all modules

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -374,36 +374,4 @@ export class Utils {
       return path1 + '/' + path2;
     }
   }
-
-  public static savePointsMarkedImage({
-    image,
-    name,
-    points,
-    folderPath,
-    rgba,
-  }: {
-    image: Image;
-    name: string;
-    points: { x: number; y: number }[];
-    folderPath: string;
-    rgba?: { r: number; g: number; b: number; a: number };
-  }) {
-    const filepath = `${folderPath}/${name}.png`;
-
-    // if file exists, skip
-    const res = execute(`test -e ${filepath} && echo 1`);
-    if (res === '1') {
-      return;
-    }
-    const clonedImg = clone(image);
-    const { r, g, b, a } = rgba || { r: 255, g: 0, b: 0, a: 255 };
-    const radius = 3;
-    for (const i in points) {
-      const { x, y } = points[i];
-      drawCircle(clonedImg, x, y, radius, r, g, b, a);
-    }
-    saveImage(clonedImg, filepath);
-    releaseImage(clonedImg);
-    console.log(`[savePointsMarkedImage]: ${name}`);
-  }
 }


### PR DESCRIPTION
## Summary
- Remove the opt-in `savePageReference` config and related page point-mark screenshot helper
- Delete `savePageReferenceImage` and `Utils.savePointsMarkedImage`, which were only used for this debug path

## Test plan
- [ ] Confirm scripts no longer set `rerouterConfig.savePageReference`
- [ ] Smoke-test route matching still works without the removed debug hook
- [ ] `npm run compile` succeeds