### PR TITLE
refactor: remove unused testingScreenshotPath config

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -7,7 +7,6 @@ export const DEFAULT_REROUTER_CONFIG: RerouterConfig = {
   startAppDelay: 6000,
   autoLaunchApp: true,
   inAppExtraPackageNames: [],
-  testingScreenshotPath: './screenshot',
   instanceId: '',
   deviceId: '',
   strictMode: false,

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -199,7 +199,6 @@ export interface RerouterConfig {
   autoLaunchApp: boolean;
   /** Additional package names considered as "in app" (e.g. browser/WebView during OAuth login flow) */
   inAppExtraPackageNames: string[];
-  testingScreenshotPath: string;
   instanceId: string; // the ID of the framework instance
   deviceId: string; // the ID of the device the framework runs on
   strictMode: boolean;


### PR DESCRIPTION
## Summary
- Remove unused `testingScreenshotPath` from `RerouterConfig` and defaults
- Field has never been referenced by runtime code or scripts

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm no script sets `testingScreenshotPath`