### PR TITLE
refactor: remove unused Utils.joinPaths

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,16 +362,4 @@ export class Utils {
 
     return deletedCount;
   }
-
-  public static joinPaths(path1: string, path2: string) {
-    if (path2 === '') {
-      return path1;
-    }
-
-    if (path1.charAt(path1.length - 1) === '/') {
-      return path1 + path2;
-    } else {
-      return path1 + '/' + path2;
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- Remove `Utils.joinPaths`, which has no remaining callers after earlier save-path refactors and `savePageReference` removal

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm no script calls `Utils.joinPaths`