### PR TITLE
refactor: remove unused XYRGBThres config

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -43,7 +43,6 @@ export const DEFAULT_SCREEN_CONFIG: ScreenConfig = {
 
 // NOTE: we should not use this config, but use rerouter.configValue instead
 export const DEFAULT_CONFIG_VALUE: ConfigValue = {
-  XYRGBThres: 0.9,
   PageThres: 0.9,
   GroupPageThres: 0.9,
   GroupPageMatchOP: '||',

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -225,7 +225,6 @@ export type ConflictRoutesHandler = (args: {
 }) => void;
 
 export interface ConfigValue {
-  XYRGBThres: number;
   PageThres: number;
   GroupPageThres: number;
   GroupPageMatchOP: '||' | '&&';


### PR DESCRIPTION
## Summary
- Remove unused `ConfigValue.XYRGBThres`; matching uses `point.thres ?? page.thres ?? PageThres` instead

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm no script references `XYRGBThres`