### PR TITLE
refactor: remove unused GroupPageMatchOP config

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -45,7 +45,6 @@ export const DEFAULT_SCREEN_CONFIG: ScreenConfig = {
 export const DEFAULT_CONFIG_VALUE: ConfigValue = {
   PageThres: 0.9,
   GroupPageThres: 0.9,
-  GroupPageMatchOP: '||',
   RouteConfigShouldMatchTimes: 1,
   RouteConfigShouldMatchDuring: 0,
   RouteConfigBeforeActionDelay: 250,

--- a/src/struct.ts
+++ b/src/struct.ts
@@ -227,7 +227,6 @@ export type ConflictRoutesHandler = (args: {
 export interface ConfigValue {
   PageThres: number;
   GroupPageThres: number;
-  GroupPageMatchOP: '||' | '&&';
   RouteConfigShouldMatchTimes: number;
   RouteConfigShouldMatchDuring: number;
   RouteConfigBeforeActionDelay: number;


### PR DESCRIPTION
## Summary
- Remove unused `ConfigValue.GroupPageMatchOP`
- `GroupPage` continues to default `matchOP` to `'||'` in its constructor

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm no script references `GroupPageMatchOP`