### PR TITLE
refactor: remove unused Utils.padZero

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,10 +229,6 @@ export class Utils {
     return false;
   }
 
-  public static padZero(num: number) {
-    return num < 10 ? `0${num}` : `${num}`;
-  }
-
   public static saveScreenshotToDisk(
     folderPath: string,
     suffix: string = '',


### PR DESCRIPTION
## Summary
- Remove unused `Utils.padZero`; timestamp formatting already goes through `timeLabel`
- Script-local `padZero` helpers are unchanged

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm no script calls `Utils.padZero`