### PR TITLE
refactor: remove unused Utils.sortStringNumberMap

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,15 +25,6 @@ export class Utils {
     return `{ x: ${x}, y: ${y}, r: ${r}, g: ${g}, b: ${b} }`;
   }
 
-  public static sortStringNumberMap(map: { [key: string]: number }): { key: string; count: number }[] {
-    const results: { key: string; count: number }[] = [];
-    for (const key in map) {
-      results.push({ key, count: map[key] });
-    }
-    results.sort((a, b) => b.count - a.count);
-    return results;
-  }
-
   public static sleep(during: number) {
     while (during > 200) {
       during -= 200;


### PR DESCRIPTION
## Summary
- Remove unused `Utils.sortStringNumberMap` from robotmon-rerouter
- Callers such as tsum-stadium use a local forked Utils, not this package

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm no script calls `Utils.sortStringNumberMap` from `robotmon-rerouter`