### PR TITLE
refactor: remove unused Screen.findImage and tapImage

### DIFF
--- a/src/screen.ts
+++ b/src/screen.ts
@@ -151,18 +151,6 @@ export class Screen {
     }
   }
 
-  public findImage(devImg: Image): { score: number; x: number; y: number } {
-    const img = this.getCvtDevScreenshot();
-    const result = findImage(img, devImg);
-    releaseImage(img);
-    return result;
-  }
-
-  public tapImage(devImg: Image) {
-    const xy = this.findImage(devImg);
-    this.tap(xy);
-  }
-
   public isSameColor(devColorPoint: XYRGB, thres: number = 0.9): boolean {
     const rgb = this.getScreenColor(devColorPoint);
     const score = Utils.identityColor(rgb, devColorPoint);


### PR DESCRIPTION
## Summary
- Remove unused `Screen.findImage` and `Screen.tapImage` wrappers
- Scripts already use Robotmon global `findImage` / `findImages` directly

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm no script calls `screen.findImage` / `screen.tapImage`