### PR TITLE
refactor: remove unused Screen.debug flag

### DIFF
--- a/src/screen.ts
+++ b/src/screen.ts
@@ -4,8 +4,6 @@ import { DEFAULT_REROUTER_CONFIG } from './defaults';
 import { overrideConsole } from './overrides';
 
 export class Screen {
-  public static debug: boolean = false;
-
   private config: ScreenConfig;
 
   public constructor(config: ScreenConfig) {


### PR DESCRIPTION
## Summary
- Remove unused `Screen.debug` static flag that was never read by runtime code

## Test plan
- [ ] `npm run compile` succeeds
- [ ] Confirm robotmon-rerouter scripts do not depend on `Screen.debug`