### PR TITLE
refactor: remove unused getPagesMatchImage debug parameter

### DIFF
--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -333,7 +333,7 @@ export class Rerouter {
     return match;
   }
 
-  public getPagesMatchImage(groupPage: GroupPage, image: Image, parentThres?: number, debug?: boolean): Page[] {
+  public getPagesMatchImage(groupPage: GroupPage, image: Image, parentThres?: number): Page[] {
     let pages: Page[] = [];
     const thres = groupPage.thres ?? parentThres ?? this.defaultConfig.PageThres;
 


### PR DESCRIPTION
## Summary
- remove the unused `debug` parameter from `getPagesMatchImage`
- preserve existing matching behavior through `this.debug`

## Test plan
- [x] Run `tsc --noEmit`
- [x] Check linter diagnostics for `src/rerouter.ts`