### PR TITLE
feat: skip Samsung-only checks on non-Samsung devices (1.6.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robotmon-rerouter",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "robotmon rerouter framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,12 +140,7 @@ export class Utils {
       return samsungDevice;
     }
     const manufacturer = execute('getprop ro.product.manufacturer');
-    if (!manufacturer || manufacturer.indexOf('exit status') !== -1) {
-      samsungDeviceKnown = true;
-      samsungDevice = false;
-      return false;
-    }
-    samsungDevice = manufacturer.toLowerCase().indexOf('samsung') !== -1;
+    samsungDevice = (manufacturer || '').toLowerCase().indexOf('samsung') !== -1;
     samsungDeviceKnown = true;
     return samsungDevice;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,9 @@
 import { overrideConsole } from './overrides';
 import { DEFAULT_REROUTER_CONFIG } from './defaults';
 
+var samsungDeviceKnown = false;
+var samsungDevice = false;
+
 export class Utils {
   public static identityColor(e1: RGB, e2: RGB) {
     const mean = (e1.r + e2.r) / 2;
@@ -132,6 +135,21 @@ export class Utils {
     return [packageName, activityName];
   }
 
+  public static isSamsungDevice(): boolean {
+    if (samsungDeviceKnown) {
+      return samsungDevice;
+    }
+    const manufacturer = execute('getprop ro.product.manufacturer');
+    if (!manufacturer || manufacturer.indexOf('exit status') !== -1) {
+      samsungDeviceKnown = true;
+      samsungDevice = false;
+      return false;
+    }
+    samsungDevice = manufacturer.toLowerCase().indexOf('samsung') !== -1;
+    samsungDeviceKnown = true;
+    return samsungDevice;
+  }
+
   public static isScreenAsleep(): boolean {
     const powerInfo = execute('dumpsys power | grep getWakefulnessLocked');
     // getWakefulnessLocked()=Asleep means screen is asleep
@@ -149,19 +167,21 @@ export class Utils {
   }
 
   public static isAppOnTop(packageName: string | string[]): boolean {
-    // Check if screen is asleep first
-    if (Utils.isScreenAsleep()) {
-      // Press wakeup to wake up the screen
-      console.log('Screen is asleep, pressing WAKEUP to wake up');
-      keycode('WAKEUP', 100);
-      Utils.sleep(500);
-    }
+    if (Utils.isSamsungDevice()) {
+      // Check if screen is asleep first
+      if (Utils.isScreenAsleep()) {
+        // Press wakeup to wake up the screen
+        console.log('Screen is asleep, pressing WAKEUP to wake up');
+        keycode('WAKEUP', 100);
+        Utils.sleep(500);
+      }
 
-    // Check for GameBooster Lock Screen
-    if (Utils.isGameBoosterLockScreen()) {
-      console.log('GameBooster Lock Screen detected, attempting to remove gametool process');
-      execute('am force-stop com.samsung.android.game.gametools');
-      Utils.sleep(500);
+      // Check for GameBooster Lock Screen
+      if (Utils.isGameBoosterLockScreen()) {
+        console.log('GameBooster Lock Screen detected, attempting to remove gametool process');
+        execute('am force-stop com.samsung.android.game.gametools');
+        Utils.sleep(500);
+      }
     }
 
     const topInfo = execute('dumpsys activity activities | grep mResumedActivity');


### PR DESCRIPTION
## Summary
- Add `Utils.isSamsungDevice()` that caches `getprop ro.product.manufacturer` and returns true only when manufacturer contains `samsung`.
- Run `isScreenAsleep()` and `isGameBoosterLockScreen()` only on Samsung devices inside `isAppOnTop()`.
- Bump version to `1.6.1`.

## Motivation
On redroid and other non-Samsung environments, the Samsung-specific `dumpsys | grep` checks fail every route loop and spam `[Error] exit status 1` logs, even though the logic already returns false. These checks are only needed on real Samsung phones (Game Booster lock screen, getWakefulnessLocked).

## Test plan
- [ ] On redroid (`manufacturer=redroid`): `isAppOnTop()` no longer runs getWakefulnessLocked / GameBooster grep; grep Error logs should stop.
- [ ] On Samsung real device (`manufacturer=samsung`): screen wake + Game Booster handling still runs as before.
- [ ] `mResumedActivity` check still runs on all devices.