### PR TITLE
ci: auto-publish to npm on version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish npm
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
+      - package-lock.json
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+
+      - name: Get package version
+        id: version
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already published
+        id: check
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          if npm view "robotmon-rerouter@${VERSION}" version 2>/dev/null; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} is already on npm, skipping."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} is not on npm, will publish."
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.published == 'false'
+        run: npm ci
+
+      - name: Publish to npm
+        if: steps.check.outputs.published == 'false'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create git tag
+        if: steps.check.outputs.published == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          TAG="v${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists, skipping."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "Release ${TAG}"
+            git push origin "$TAG"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
       - package-lock.json
 
 permissions:
+  id-token: write
   contents: write
 
 jobs:
@@ -19,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Get package version
@@ -45,8 +46,6 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.published == 'false'
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag
         if: steps.check.outputs.published == 'false'


### PR DESCRIPTION
## Summary
- Add GitHub Action to auto-publish `robotmon-rerouter` to npm when `package.json` version is bumped on `master`
- Skips publish if the version already exists on npm
- Creates matching `v*` git tag after successful publish

## Setup required (one-time)
Add repo secret `NPM_TOKEN` with an npm **Automation** token that can publish `robotmon-rerouter`.

## Test plan
- [ ] Merge this PR after adding `NPM_TOKEN` secret
- [ ] Re-run workflow manually or bump version on master
- [ ] Confirm `npm view robotmon-rerouter version` shows the new version