### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robotmon-rerouter",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "description": "robotmon rerouter framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump to **1.7.0** for the context-aware \`goNext()\` / \`goBack()\` change (too large for a patch bump)

## Test plan
- [ ] Confirm npm publishes 1.7.0 after merge