### PR TITLE
feat: fall back to GroupPage next/back when child page has none

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robotmon-rerouter",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "robotmon rerouter framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -292,7 +292,7 @@ export class Rerouter {
 
   /**
    * Tap next. Prefer no-arg call inside route action (uses active match context).
-   * - 1 matched page → that page's next
+   * - 1 matched page → that page's next; if missing, fall back to route match (GroupPage/Page) next
    * - 2+ matched pages → route match (GroupPage/Page) next
    * - With explicit page arg → that page's next (legacy / outside match context)
    */
@@ -325,7 +325,7 @@ export class Rerouter {
     }
 
     if (this.activeMatchedPages.length === 1) {
-      return this.activeMatchedPages[0][kind];
+      return this.activeMatchedPages[0][kind] ?? this.activeMatch?.[kind];
     }
     if (this.activeMatchedPages.length >= 2 && this.activeMatch !== null) {
       return this.activeMatch[kind];


### PR DESCRIPTION
## Summary
- When exactly one GroupPage child matches, `goNext()` / `goBack()` still prefer that page's `next` / `back`
- If the matched child has no coordinate, fall back to the route match (`GroupPage` / `Page`) coordinate
- Explicit `goNext(page)` / `goBack(page)` still do not fall back

## Test plan
- [ ] GroupPage matches 1 child with `next` → taps child `next`
- [ ] GroupPage matches 1 child without `next`, group has `next` → taps group `next`
- [ ] GroupPage matches 1 child without `next`, group also missing → warning, no tap
- [ ] GroupPage matches 2+ children → still taps group `next`
- [ ] `goNext(explicitPage)` with no `next` → warning, does not use group