### PR TITLE
fix: only update local game status after cloud succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robotmon-rerouter",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "robotmon rerouter framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -953,24 +953,19 @@ export class Rerouter {
   }
 
   public updateGameStatus(status: GameStatus): boolean {
-    this.localGameStatus = status; // Update local status first
-
-    if (status === GameStatus.NEW_ACCOUNT) {
-      sendEvent(EventName.RUNNING, '');
-    }
-
     // If instanceId or deviceId is empty, skip updating cloud status
     if (!this.rerouterConfig.instanceId || !this.rerouterConfig.deviceId) {
       console.warn('Instance ID or Device ID is empty. Skipping cloud status update.');
+      this.localGameStatus = status;
+      if (status === GameStatus.NEW_ACCOUNT) {
+        sendEvent(EventName.RUNNING, '');
+      }
       return true; // Local update is considered successful
     }
 
     if (this.cloudGameStatus === status) {
-      return false; // No update is needed if the cloud status hasn't changed
-    }
-
-    if (this.rerouterConfig.deviceId === '' || this.rerouterConfig.instanceId === '') {
-      console.log(`deviceId or instanceId is empty, cannot update game status`);
+      // Keep local in sync with known cloud status; no cloud write needed
+      this.localGameStatus = status;
       return false;
     }
 
@@ -981,8 +976,13 @@ export class Rerouter {
       const result = xrUpdateGameStatus(this.rerouterConfig.deviceId, this.rerouterConfig.instanceId, status);
 
       if (result === true) {
-        this.cloudGameStatus = status; // Update cloud status on success
-        return true; // Operation successful, return true
+        // Only update local after cloud succeeds, to avoid local/cloud drift
+        this.localGameStatus = status;
+        this.cloudGameStatus = status;
+        if (status === GameStatus.NEW_ACCOUNT) {
+          sendEvent(EventName.RUNNING, '');
+        }
+        return true;
       }
 
       attempts++;
@@ -994,7 +994,7 @@ export class Rerouter {
       Utils.sleep(3000); // Sleep between attempts
     }
 
-    return false; // Return false after all attempts failed
+    return false; // Return false after all attempts failed; local unchanged
   }
 
   public getGameStatus(): GameStatus | null {

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -953,13 +953,14 @@ export class Rerouter {
   }
 
   public updateGameStatus(status: GameStatus): boolean {
+    if (status === GameStatus.NEW_ACCOUNT) {
+      sendEvent(EventName.RUNNING, '');
+    }
+
     // If instanceId or deviceId is empty, skip updating cloud status
     if (!this.rerouterConfig.instanceId || !this.rerouterConfig.deviceId) {
       console.warn('Instance ID or Device ID is empty. Skipping cloud status update.');
       this.localGameStatus = status;
-      if (status === GameStatus.NEW_ACCOUNT) {
-        sendEvent(EventName.RUNNING, '');
-      }
       return true; // Local update is considered successful
     }
 
@@ -979,9 +980,6 @@ export class Rerouter {
         // Only update local after cloud succeeds, to avoid local/cloud drift
         this.localGameStatus = status;
         this.cloudGameStatus = status;
-        if (status === GameStatus.NEW_ACCOUNT) {
-          sendEvent(EventName.RUNNING, '');
-        }
         return true;
       }
 


### PR DESCRIPTION
## Summary
- `updateGameStatus` no longer sets `localGameStatus` before the cloud write succeeds
- On API failure after retries, local status stays unchanged so callers can retry cleanly
- When device/instance id is missing, still update local only (offline/dev path)

## Test plan
- [ ] With valid deviceId/instanceId, successful status update sets both local and cloud
- [ ] Simulate cloud API failure: `getGameStatus()` remains previous value, return `false`
- [ ] Retry same status after failure still attempts cloud write
- [ ] Empty deviceId/instanceId still updates local and returns `true`