### PR TITLE
revert: restore updateGameStatus local-first semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robotmon-rerouter",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "robotmon rerouter framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/rerouter.ts
+++ b/src/rerouter.ts
@@ -953,6 +953,8 @@ export class Rerouter {
   }
 
   public updateGameStatus(status: GameStatus): boolean {
+    this.localGameStatus = status; // Update local status first
+
     if (status === GameStatus.NEW_ACCOUNT) {
       sendEvent(EventName.RUNNING, '');
     }
@@ -960,13 +962,15 @@ export class Rerouter {
     // If instanceId or deviceId is empty, skip updating cloud status
     if (!this.rerouterConfig.instanceId || !this.rerouterConfig.deviceId) {
       console.warn('Instance ID or Device ID is empty. Skipping cloud status update.');
-      this.localGameStatus = status;
       return true; // Local update is considered successful
     }
 
     if (this.cloudGameStatus === status) {
-      // Keep local in sync with known cloud status; no cloud write needed
-      this.localGameStatus = status;
+      return false; // No update is needed if the cloud status hasn't changed
+    }
+
+    if (this.rerouterConfig.deviceId === '' || this.rerouterConfig.instanceId === '') {
+      console.log(`deviceId or instanceId is empty, cannot update game status`);
       return false;
     }
 
@@ -977,10 +981,8 @@ export class Rerouter {
       const result = xrUpdateGameStatus(this.rerouterConfig.deviceId, this.rerouterConfig.instanceId, status);
 
       if (result === true) {
-        // Only update local after cloud succeeds, to avoid local/cloud drift
-        this.localGameStatus = status;
-        this.cloudGameStatus = status;
-        return true;
+        this.cloudGameStatus = status; // Update cloud status on success
+        return true; // Operation successful, return true
       }
 
       attempts++;
@@ -992,7 +994,7 @@ export class Rerouter {
       Utils.sleep(3000); // Sleep between attempts
     }
 
-    return false; // Return false after all attempts failed; local unchanged
+    return false; // Return false after all attempts failed
   }
 
   public getGameStatus(): GameStatus | null {


### PR DESCRIPTION
## Summary
- Revert #85: restore original `updateGameStatus` behavior (update `localGameStatus` first, update `cloudGameStatus` only on cloud success)
- Dual status is intentional: local = current state for `getGameStatus()`, cloud = last synced value for dedupe/retry
- Bump version to `1.7.3`

## Test plan
- [ ] `updateGameStatus` sets local immediately even if cloud API fails
- [ ] Failed cloud write leaves `cloudGameStatus` unchanged so a later same-status call retries
- [ ] Successful write skips subsequent identical cloud updates
- [ ] Publish `1.7.3` after merge